### PR TITLE
Fix url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **skrl** is an open-source modular library for Reinforcement Learning written in Python (using [PyTorch](https://pytorch.org/)) and designed with a focus on readability, simplicity, and transparency of algorithm implementation
 
-In addition to supporting the [Gym](https://gym.openai.com/) interface, it allows loading and configuring [NVIDIA Isaac Gym](https://developer.nvidia.com/isaac-gym>) environments, enabling agents' simultaneous training by scopes (subsets of environments among all available environments), which may or may not share resources, in the same run
+In addition to supporting the [Gym](https://gym.openai.com/) interface, it allows loading and configuring [NVIDIA Isaac Gym](https://developer.nvidia.com/isaac-gym/) environments, enabling agents' simultaneous training by scopes (subsets of environments among all available environments), which may or may not share resources, in the same run
 
 ### Please, visit the documentation for usage details and examples
 


### PR DESCRIPTION
The url to NVIDIA Isaac Gym has a wrong character so the link does not work.