### PR TITLE
return render frames from gymnasium render function

### DIFF
--- a/skrl/envs/torch/wrappers.py
+++ b/skrl/envs/torch/wrappers.py
@@ -625,10 +625,11 @@ class GymnasiumWrapper(Wrapper):
         observation, info = self._env.reset()
         return self._observation_to_tensor(observation), info
 
-    def render(self, *args, **kwargs) -> None:
+    def render(self, *args, **kwargs) -> gymnasium.core.RenderFrame | list[gymnasium.core.RenderFrame] | None:
         """Render the environment
         """
-        self._env.render(*args, **kwargs)
+        return self._env.render(*args, **kwargs)
+
 
     def close(self) -> None:
         """Close the environment


### PR DESCRIPTION
The gymnasium render function returns frames in RGB array mode. This commit just passes through the return of the gymnasium render 

This is useful for saving animations for demonstrations