### PR TITLE
Do not save checkpoints for eval runs

### DIFF
--- a/skrl/agents/jax/base.py
+++ b/skrl/agents/jax/base.py
@@ -452,7 +452,7 @@ class Agent:
         """
         pass
 
-    def post_interaction(self, timestep: int, timesteps: int) -> None:
+    def post_interaction(self, timestep: int, timesteps: int, save_checkpoints: bool = True) -> None:
         """Callback called after the interaction with the environment
 
         :param timestep: Current timestep
@@ -463,7 +463,7 @@ class Agent:
         timestep += 1
 
         # update best models and write checkpoints
-        if timestep > 1 and self.checkpoint_interval > 0 and not timestep % self.checkpoint_interval:
+        if save_checkpoints and timestep > 1 and self.checkpoint_interval > 0 and not timestep % self.checkpoint_interval:
             # update best models
             reward = np.mean(self.tracking_data.get("Reward / Total reward (mean)", -2 ** 31))
             if reward > self.checkpoint_best_modules["reward"]:

--- a/skrl/agents/torch/base.py
+++ b/skrl/agents/torch/base.py
@@ -625,7 +625,7 @@ class Agent:
         """
         pass
 
-    def post_interaction(self, timestep: int, timesteps: int) -> None:
+    def post_interaction(self, timestep: int, timesteps: int, save_checkpoints: bool = True) -> None:
         """Callback called after the interaction with the environment
 
         :param timestep: Current timestep
@@ -636,7 +636,7 @@ class Agent:
         timestep += 1
 
         # update best models and write checkpoints
-        if timestep > 1 and self.checkpoint_interval > 0 and not timestep % self.checkpoint_interval:
+        if save_checkpoints and timestep > 1 and self.checkpoint_interval > 0 and not timestep % self.checkpoint_interval:
             # update best models
             reward = np.mean(self.tracking_data.get("Reward / Total reward (mean)", -2 ** 31))
             if reward > self.checkpoint_best_modules["reward"]:

--- a/skrl/trainers/jax/base.py
+++ b/skrl/trainers/jax/base.py
@@ -243,7 +243,7 @@ class Trainer:
                                               infos=infos,
                                               timestep=timestep,
                                               timesteps=self.timesteps)
-                super(type(self.agents), self.agents).post_interaction(timestep=timestep, timesteps=self.timesteps)
+                super(type(self.agents), self.agents).post_interaction(timestep=timestep, timesteps=self.timesteps, save_checkpoints=False)
 
             # reset environments
             if self.env.num_envs > 1:
@@ -362,7 +362,7 @@ class Trainer:
                                               infos=infos,
                                               timestep=timestep,
                                               timesteps=self.timesteps)
-                super(type(self.agents), self.agents).post_interaction(timestep=timestep, timesteps=self.timesteps)
+                super(type(self.agents), self.agents).post_interaction(timestep=timestep, timesteps=self.timesteps, save_checkpoints=False)
 
                 # reset environments
                 if not self.env.agents:

--- a/skrl/trainers/jax/sequential.py
+++ b/skrl/trainers/jax/sequential.py
@@ -185,7 +185,7 @@ class SequentialTrainer(Trainer):
                                             infos=infos,
                                             timestep=timestep,
                                             timesteps=self.timesteps)
-                    super(type(agent), agent).post_interaction(timestep=timestep, timesteps=self.timesteps)
+                    super(type(agent), agent).post_interaction(timestep=timestep, timesteps=self.timesteps, save_checkpoints=False)
 
                 # reset environments
                 if terminated.any() or truncated.any():

--- a/skrl/trainers/jax/step.py
+++ b/skrl/trainers/jax/step.py
@@ -245,7 +245,7 @@ class StepTrainer(Trainer):
                                               infos=infos,
                                               timestep=timestep,
                                               timesteps=timesteps)
-                super(type(self.agents), self.agents).post_interaction(timestep=timestep, timesteps=timesteps)
+                super(type(self.agents), self.agents).post_interaction(timestep=timestep, timesteps=timesteps, save_checkpoints=False)
 
             else:
                 # write data to TensorBoard
@@ -259,7 +259,7 @@ class StepTrainer(Trainer):
                                             infos=infos,
                                             timestep=timestep,
                                             timesteps=timesteps)
-                    super(type(agent), agent).post_interaction(timestep=timestep, timesteps=timesteps)
+                    super(type(agent), agent).post_interaction(timestep=timestep, timesteps=timesteps, save_checkpoints=False)
 
             # reset environments
             if terminated.any() or truncated.any():

--- a/skrl/trainers/torch/base.py
+++ b/skrl/trainers/torch/base.py
@@ -242,7 +242,7 @@ class Trainer:
                                               infos=infos,
                                               timestep=timestep,
                                               timesteps=self.timesteps)
-                super(type(self.agents), self.agents).post_interaction(timestep=timestep, timesteps=self.timesteps)
+                super(type(self.agents), self.agents).post_interaction(timestep=timestep, timesteps=self.timesteps, save_checkpoints=False)
 
             # reset environments
             if self.env.num_envs > 1:
@@ -359,7 +359,7 @@ class Trainer:
                                               infos=infos,
                                               timestep=timestep,
                                               timesteps=self.timesteps)
-                super(type(self.agents), self.agents).post_interaction(timestep=timestep, timesteps=self.timesteps)
+                super(type(self.agents), self.agents).post_interaction(timestep=timestep, timesteps=self.timesteps, save_checkpoints=False)
 
                 # reset environments
                 if not self.env.agents:

--- a/skrl/trainers/torch/parallel.py
+++ b/skrl/trainers/torch/parallel.py
@@ -99,7 +99,7 @@ def fn_processor(process_index, *args):
                                         infos=queue.get(),
                                         timestep=msg['timestep'],
                                         timesteps=msg['timesteps'])
-                super(type(agent), agent).post_interaction(timestep=msg['timestep'], timesteps=msg['timesteps'])
+                super(type(agent), agent).post_interaction(timestep=msg['timestep'], timesteps=msg['timesteps'], save_checkpoints=False)
                 barrier.wait()
 
 

--- a/skrl/trainers/torch/sequential.py
+++ b/skrl/trainers/torch/sequential.py
@@ -182,7 +182,7 @@ class SequentialTrainer(Trainer):
                                             infos=infos,
                                             timestep=timestep,
                                             timesteps=self.timesteps)
-                    super(type(agent), agent).post_interaction(timestep=timestep, timesteps=self.timesteps)
+                    super(type(agent), agent).post_interaction(timestep=timestep, timesteps=self.timesteps, save_checkpoints=False)
 
                 # reset environments
                 if terminated.any() or truncated.any():

--- a/skrl/trainers/torch/step.py
+++ b/skrl/trainers/torch/step.py
@@ -240,7 +240,7 @@ class StepTrainer(Trainer):
                                               infos=infos,
                                               timestep=timestep,
                                               timesteps=timesteps)
-                super(type(self.agents), self.agents).post_interaction(timestep=timestep, timesteps=timesteps)
+                super(type(self.agents), self.agents).post_interaction(timestep=timestep, timesteps=timesteps, save_checkpoints=False)
 
             else:
                 # write data to TensorBoard
@@ -254,7 +254,7 @@ class StepTrainer(Trainer):
                                             infos=infos,
                                             timestep=timestep,
                                             timesteps=timesteps)
-                    super(type(agent), agent).post_interaction(timestep=timestep, timesteps=timesteps)
+                    super(type(agent), agent).post_interaction(timestep=timestep, timesteps=timesteps, save_checkpoints=False)
 
             # reset environments
             if terminated.any() or truncated.any():


### PR DESCRIPTION
Motivation:
Currently both train and eval modes are saving checkpoints, and best checkpoint. This was causing some troubles on our side when we implemented parallel validation runs that were then overwriting the checkpoints from the train run.

This change is passing a boolean flag save_checkpoint into post interaction function, which is set to False in case it is called from eval mode.


