### PR TITLE
Fix isaaclab wrapper exception info is not assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Catch TensorBoard summary iterator exceptions in `TensorboardFileIterator` postprocessing utils
+- Fixed uninitialized info variable in IsaacLabWrappers for env reset by setting info to empty dictionary when reset_once is false.
 
 ## [1.2.0] - 2024-06-23
 ### Added

--- a/skrl/envs/wrappers/jax/isaaclab_envs.py
+++ b/skrl/envs/wrappers/jax/isaaclab_envs.py
@@ -80,6 +80,8 @@ class IsaacLabWrapper(Wrapper):
         if self._reset_once:
             self._obs_dict, info = self._env.reset()
             self._reset_once = False
+        else:
+            info = {}
         return _torch2jax(self._obs_dict["policy"], self._jax), info
 
     def render(self, *args, **kwargs) -> None:

--- a/skrl/envs/wrappers/torch/isaaclab_envs.py
+++ b/skrl/envs/wrappers/torch/isaaclab_envs.py
@@ -40,6 +40,8 @@ class IsaacLabWrapper(Wrapper):
         if self._reset_once:
             self._obs_dict, info = self._env.reset()
             self._reset_once = False
+        else:
+            info = {}
         return self._obs_dict["policy"], info
 
     def render(self, *args, **kwargs) -> None:


### PR DESCRIPTION
When the num_envs is 1, IsaacLab wrapper was causing a crash on the application because SequentialTrainer tries to reset but after single reset ```info``` variable is unassigned. In this MR I fixed it by setting the info as an empty dictionary when the ```reset_once``` is false.