### PR TITLE
Fix Test run: return `create_tensor(... keep_dimensions)` default to `False`

### DIFF
--- a/skrl/memories/torch/base.py
+++ b/skrl/memories/torch/base.py
@@ -171,7 +171,7 @@ class Memory:
                       name: str,
                       size: Union[int, Tuple[int], gym.Space, gymnasium.Space],
                       dtype: Optional[torch.dtype] = None,
-                      keep_dimensions: bool = True) -> bool:
+                      keep_dimensions: bool = False) -> bool:
         """Create a new internal tensor in memory
 
         The tensor will have a 3-components shape (memory size, number of environments, size).


### PR DESCRIPTION
### TLDR:
Change `create_tensor(... keep_dimensions = False)` as it was before (and is still in doc string)

### Explanation
The default value of `keep_dimensions` was changed to `True`, making agents initialization fail during inference (test run).

For example, `agents.ppo.py :: PPO.init` fails because `self.memory.create_tensor` uses the default value for `keep_dimensions`.
```
class PPO(...):
  def init(...):
        ...
        # create tensors in memory
        if self.memory is not None:
            self.memory.create_tensor(name="states", size=self.observation_space, dtype=torch.float32)
            self.memory.create_tensor(name="actions", size=self.action_space, dtype=torch.float32)
```

#### Doc string consistency
The doc string still says the default is `False`, so it might have been an unintentional commit.
```
def create_tensor(self,
                      ...
                      keep_dimensions: bool = True) -> bool:
        """Create a new internal tensor in memory
        ...
        :param keep_dimensions: Whether or not to keep the dimensions defined through the size parameter (default: ``False``)
        :type keep_dimensions: bool, optional
```