### PR TITLE
Fix: with SAC, a new training batch should be sampled for each gradient step

### DIFF
--- a/skrl/agents/torch/sac/sac.py
+++ b/skrl/agents/torch/sac/sac.py
@@ -310,7 +310,7 @@ class SAC(Agent):
         """
         # gradient steps
         for gradient_step in range(self._gradient_steps):
-            
+
             # sample a batch from memory
             sampled_states, sampled_actions, sampled_rewards, sampled_next_states, sampled_dones = \
             self.memory.sample(names=self._tensors_names, batch_size=self._batch_size)[0]

--- a/skrl/agents/torch/sac/sac.py
+++ b/skrl/agents/torch/sac/sac.py
@@ -308,12 +308,12 @@ class SAC(Agent):
         :param timesteps: Number of timesteps
         :type timesteps: int
         """
-        # sample a batch from memory
-        sampled_states, sampled_actions, sampled_rewards, sampled_next_states, sampled_dones = \
-            self.memory.sample(names=self._tensors_names, batch_size=self._batch_size)[0]
-
         # gradient steps
         for gradient_step in range(self._gradient_steps):
+            
+            # sample a batch from memory
+            sampled_states, sampled_actions, sampled_rewards, sampled_next_states, sampled_dones = \
+            self.memory.sample(names=self._tensors_names, batch_size=self._batch_size)[0]
 
             sampled_states = self._state_preprocessor(sampled_states, train=True)
             sampled_next_states = self._state_preprocessor(sampled_next_states, train=True)


### PR DESCRIPTION
…nt_step.

[DDPG/TD3/SAC for robotics tasks #65](https://github.com/Toni-SM/skrl/discussions/65)
Increasing the number of parallel simulations accelerates the replay buffer data refresh rate in SAC and other off-policy algorithms. However, to fully leverage this increased data collection, the model should be updated more frequently. This can be achieved by increasing `self._gradient_steps`.

**Issue:**

**- Current Behavior:** The current implementation reuses the same training batch across multiple gradient steps, which can lead to overfitting and inefficient use of the new data collected from parallel simulations.

**- Expected Behavior:** According to the  [SAC algorithm implementation](https://spinningup.openai.com/en/latest/algorithms/sac.html), a new training batch should be sampled for each gradient step to ensure diverse and fresh experiences are used for updates.

**Fixed Implemented:**

- Modified the SAC training loop to sample a new training batch from the replay buffer for each gradient step.