### PR TITLE
add class mapping of categorical model

### DIFF
--- a/skrl/utils/runner/jax/runner.py
+++ b/skrl/utils/runner/jax/runner.py
@@ -14,7 +14,7 @@ from skrl.resources.preprocessors.jax import RunningStandardScaler  # noqa
 from skrl.resources.schedulers.jax import KLAdaptiveLR  # noqa
 from skrl.trainers.jax import SequentialTrainer, Trainer
 from skrl.utils import set_seed
-from skrl.utils.model_instantiators.jax import deterministic_model, gaussian_model
+from skrl.utils.model_instantiators.jax import deterministic_model, gaussian_model, categorical_model
 
 
 class Runner:
@@ -37,6 +37,7 @@ class Runner:
             "gaussianmixin": gaussian_model,
             "deterministicmixin": deterministic_model,
             "shared": None,
+            "categoricalmixin": categorical_model,
             # memory
             "randommemory": RandomMemory,
             # agent

--- a/skrl/utils/runner/torch/runner.py
+++ b/skrl/utils/runner/torch/runner.py
@@ -14,7 +14,7 @@ from skrl.resources.preprocessors.torch import RunningStandardScaler  # noqa
 from skrl.resources.schedulers.torch import KLAdaptiveLR  # noqa
 from skrl.trainers.torch import SequentialTrainer, Trainer
 from skrl.utils import set_seed
-from skrl.utils.model_instantiators.torch import deterministic_model, gaussian_model, shared_model
+from skrl.utils.model_instantiators.torch import deterministic_model, gaussian_model, shared_model, categorical_model
 
 
 class Runner:
@@ -37,6 +37,7 @@ class Runner:
             "gaussianmixin": gaussian_model,
             "deterministicmixin": deterministic_model,
             "shared": shared_model,
+            "categoricalmixin": categorical_model,
             # memory
             "randommemory": RandomMemory,
             # agent


### PR DESCRIPTION
Added class mapping for the categorical model in the runner util. Figured out it was not included while using it in the [Isaac Lab ](https://github.com/isaac-sim/IsaacLab) framework.