### PR TITLE
Add support for per-agent `state_space` in MAPPO

### DIFF
--- a/skrl/envs/wrappers/torch/base.py
+++ b/skrl/envs/wrappers/torch/base.py
@@ -290,14 +290,20 @@ class MultiAgentEnvWrapper(object):
 
     @property
     def state_spaces(self) -> Mapping[str, gymnasium.Space]:
-        """State spaces
+        """Returns the state spaces of the environment.
 
-        Since the state space is a global view of the environment (and therefore the same for all the agents),
-        this property returns a dictionary (for consistency with the other space-related properties) with the same
-        space for all the agents
+        - The base environment can return either:
+        1. A single state space (shared by all agents).
+        2. A dictionary mapping each agent to its specific state space.
+
+        - When a dictionary is used, each key represents an agent's name, and the corresponding value is the agent's state space.
+        - This provides a global view of the environment **from each agent's perspective**.
         """
         space = self._unwrapped.state_space
-        return {agent: space for agent in self.possible_agents}
+        if isinstance(space, gymnasium.spaces.Dict):
+            return space
+        else:
+            return {agent: space for agent in self.possible_agents}
 
     @property
     def observation_spaces(self) -> Mapping[str, gymnasium.Space]:

--- a/skrl/envs/wrappers/torch/isaaclab_envs.py
+++ b/skrl/envs/wrappers/torch/isaaclab_envs.py
@@ -153,7 +153,10 @@ class IsaacLabMultiAgentWrapper(MultiAgentEnvWrapper):
         except AttributeError:  # 'OrderEnforcing' object has no attribute 'state'
             state = self._unwrapped.state()
         if state is not None:
-            return flatten_tensorized_space(tensorize_space(next(iter(self.state_spaces.values())), state))
+            if isinstance(self.state_spaces, gymnasium.spaces.Dict):
+                return tensorize_space(self.state_spaces, state)
+            else:
+                return flatten_tensorized_space(tensorize_space(next(iter(self.state_spaces.values())), state))
         return state
 
     def render(self, *args, **kwargs) -> None:


### PR DESCRIPTION
### Description

This PR introduces support for specifying per-agent `state_space` definitions in MAPPO which provides global view from each agent's perspective. Previously, `state_space` was assumed to be a single shared space for all agents, limiting flexibility in multi-agent reinforcement learning (MARL) scenarios. Now, users can define individual state spaces per agent. 

### Note:
- This feature is backward compatible.
- I have also added a proposal in IsaacSim that can utilize this feature. It can be reviewed here. https://github.com/isaac-sim/IsaacLab/issues/1887
