### PR TITLE
Fix WandB model config logging for JAX agents

### DIFF
--- a/skrl/agents/jax/base.py
+++ b/skrl/agents/jax/base.py
@@ -155,7 +155,8 @@ class Agent:
             try:
                 models_cfg = {k: v.net._modules for (k, v) in self.models.items()}
             except AttributeError:
-                models_cfg = {k: v._modules for (k, v) in self.models.items()}
+                # Framework-agnostic summary for WandB config
+                models_cfg = {k: {"type": type(v).__name__} for k, v in self.models.items()}
             wandb_config = {**self.cfg, **trainer_cfg, **models_cfg}
             # set default values
             wandb_kwargs = copy.deepcopy(self.cfg.get("experiment", {}).get("wandb_kwargs", {}))


### PR DESCRIPTION
When using the JAX backend, enabling `wandb: True` causes a crash due to PyTorch-specific model inspection (`.net._modules`). This PR adds a fallback for JAX/Flax models that logs their type instead:

```python
models_cfg = {k: {"type": type(v).__name__} for k, v in self.models.items()}
