### PR TITLE
[Updated] Info Logging: Allow parent tags in the "episode" info dict

### DIFF
--- a/skrl/trainers/torch/base.py
+++ b/skrl/trainers/torch/base.py
@@ -215,7 +215,7 @@ class Trainer(ABC):
                 if self.environment_info in infos:
                     for k, v in infos[self.environment_info].items():
                         if isinstance(v, torch.Tensor) and v.numel() == 1:
-                            self.agents.track_data(f"Info / {k}", v.item())
+                            self.agents.track_data(k if "/" in k else f"Info / {k}", v.item())
 
             # post-interaction
             self.agents.post_interaction(timestep=timestep, timesteps=self.timesteps)
@@ -311,7 +311,7 @@ class Trainer(ABC):
                 if self.environment_info in infos:
                     for k, v in infos[self.environment_info].items():
                         if isinstance(v, torch.Tensor) and v.numel() == 1:
-                            self.agents.track_data(f"Info / {k}", v.item())
+                            self.agents.track_data(k if "/" in k else f"Info / {k}", v.item())
 
             # post-interaction
             super(self.agents.__class__, self.agents).post_interaction(timestep=timestep, timesteps=self.timesteps)

--- a/skrl/trainers/torch/sequential.py
+++ b/skrl/trainers/torch/sequential.py
@@ -143,7 +143,7 @@ class SequentialTrainer(Trainer):
                     for k, v in infos[self.environment_info].items():
                         if isinstance(v, torch.Tensor) and v.numel() == 1:
                             for agent in self.agents:
-                                agent.track_data(f"Info / {k}", v.item())
+                                agent.track_data(k if "/" in k else f"Info / {k}", v.item())
 
             # post-interaction
             for agent in self.agents:
@@ -243,7 +243,7 @@ class SequentialTrainer(Trainer):
                     for k, v in infos[self.environment_info].items():
                         if isinstance(v, torch.Tensor) and v.numel() == 1:
                             for agent in self.agents:
-                                agent.track_data(f"Info / {k}", v.item())
+                                agent.track_data(k if "/" in k else f"Info / {k}", v.item())
 
             # post-interaction
             for agent in self.agents:

--- a/skrl/trainers/torch/step.py
+++ b/skrl/trainers/torch/step.py
@@ -158,7 +158,7 @@ class StepTrainer(Trainer):
                 for k, v in infos[self.environment_info].items():
                     if isinstance(v, torch.Tensor) and v.numel() == 1:
                         for agent in self.agents:
-                            agent.track_data(f"Info / {k}", v.item())
+                            agent.track_data(k if "/" in k else f"Info / {k}", v.item())
 
         # post-interaction
         for agent in self.agents:
@@ -283,7 +283,7 @@ class StepTrainer(Trainer):
                 for k, v in infos[self.environment_info].items():
                     if isinstance(v, torch.Tensor) and v.numel() == 1:
                         for agent in self.agents:
-                            agent.track_data(f"Info / {k}", v.item())
+                            agent.track_data(k if "/" in k else f"Info / {k}", v.item())
 
         # post-interaction
         for agent in self.agents:


### PR DESCRIPTION
## Change
When logging items from the `info["episode"]` dict, allow custom parent tags (i.e. `<Parent> / <Metric>`) and only add the `Info` prefix, if the item doesn't already have a parent tag. 

For example:
* `info["episode"]["avg_height"]` -> Would be logged to `Info / avg_height` (same functionality as today)
* `info["episode"]["Rewards / target_height"]` -> Would be logged to `Rewards / target_height` (new functionality)

## Why 
Hardcoding the "Info" parent tag is fine for a few metrics, but when logging a lot of data, it can be useful to segment the data across different sections ("Reward Items", "Termination causes", "Metics", etc).

## Inspiration
This is similar to how [rsl_rl handles it](https://github.com/leggedrobotics/rsl_rl/blob/bc1c7c435ae780193a2fd5d66c516c9e8f43363e/rsl_rl/runners/on_policy_runner.py#L201-L206). It's fallback parnt tag is `Episode/`.