### PR TITLE
Add else branch to avoid model instantiators' concatenate bug

### DIFF
--- a/skrl/utils/model_instantiators/jax/common.py
+++ b/skrl/utils/model_instantiators/jax/common.py
@@ -111,10 +111,11 @@ def _parse_output(source: str | list[str]) -> tuple[str | list[str], list[str], 
                 if node.func.id == "concatenate":
                     node.func = ast.Attribute(value=ast.Name("jnp"), attr="concatenate")
                     node.keywords = [ast.keyword(arg="axis", value=ast.Constant(value=-1))]
-                # activation functions
-                activation = _get_activation_function(node.func.id)
-                if activation:
-                    node.func = ast.Attribute(value=ast.Name("nn"), attr=activation.replace("nn.", ""))
+                else:
+                    # activation functions
+                    activation = _get_activation_function(node.func.id)
+                    if activation:
+                        node.func = ast.Attribute(value=ast.Name("nn"), attr=activation.replace("nn.", ""))
             return node
 
     size = get_num_units("ACTIONS")

--- a/skrl/utils/model_instantiators/torch/common.py
+++ b/skrl/utils/model_instantiators/torch/common.py
@@ -111,10 +111,11 @@ def _parse_output(source: str | list[str]) -> tuple[str | list[str], list[str], 
                 if node.func.id == "concatenate":
                     node.func = ast.Attribute(value=ast.Name("torch"), attr="cat")
                     node.keywords = [ast.keyword(arg="dim", value=ast.Constant(value=1))]
-                # activation functions
-                activation = _get_activation_function(node.func.id, as_module=False)
-                if activation:
-                    node.func = ast.Attribute(value=ast.Name("nn"), attr=activation)
+                else:
+                    # activation functions
+                    activation = _get_activation_function(node.func.id, as_module=False)
+                    if activation:
+                        node.func = ast.Attribute(value=ast.Name("nn"), attr=activation)
             return node
 
     size = get_num_units("ACTIONS")

--- a/skrl/utils/model_instantiators/warp/common.py
+++ b/skrl/utils/model_instantiators/warp/common.py
@@ -105,10 +105,11 @@ def _parse_output(source: str | list[str]) -> tuple[str | list[str], list[str], 
                 if node.func.id == "concatenate":
                     node.func = ast.Attribute(value=ast.Name("warp_utils"), attr="concatenate")
                     node.keywords = [ast.keyword(arg="axis", value=ast.Constant(value=1))]
-                # activation functions
-                activation = _get_activation_function(node.func.id, as_module=False)
-                if activation:
-                    node.func = ast.Attribute(value=ast.Name("nn"), attr=activation)
+                else:
+                    # activation functions
+                    activation = _get_activation_function(node.func.id, as_module=False)
+                    if activation:
+                        node.func = ast.Attribute(value=ast.Name("nn"), attr=activation)
             return node
 
     size = get_num_units("ACTIONS")


### PR DESCRIPTION
### Reproduce and Detailed Description

Issue #432 explains the bug and has a script to reproduce it.

### Bug Report

The model instantiators are bugged if you try to use "concatenate" in the output definition. Something like this:

```
source = gaussian_model(
        observation_space=obs_space,
        action_space=act_space,
        network=network,
        output="concatenate([head_a, head_b])",
        return_source=True,
    )
```

Error is:
```
File ".../site-packages/skrl/utils/model_instantiators/torch/common.py", line 121, in visit_Call
    activation = _get_activation_function(node.func.id, as_module=False)
                                          ^^^^^^^^^^^^
AttributeError: 'Attribute' object has no attribute 'id' 
```

**Root cause**: In _parse_output (common.py), the visit_Call method of the NodeTransformer replaces node.func with an ast.Attribute node when it encounters concatenate, but then falls through to the activation function check which assumes node.func is still an ast.Name (i.e. has .id).


### Fix
Add an `else` after the "concatenate" block so the activation function translation is skipped if the node is a concat. 

This analogous to `_parse_input` which has an `elif ...` after the `if node.func.id == "concatenate":` block