### PR TITLE
Fix multi-agent record_transition to check all agents for episode completion

### DIFF
--- a/skrl/multi_agents/jax/base.py
+++ b/skrl/multi_agents/jax/base.py
@@ -402,8 +402,8 @@ class MultiAgent(ABC):
         """
         if self.write_interval > 0:
             _rewards = sum(rewards.values())
-            _terminated = next(iter(terminated.values()))
-            _truncated = next(iter(truncated.values()))
+            _terminated = np.stack([jax.device_get(v) for v in terminated.values()]).any(axis=0)
+            _truncated = np.stack([jax.device_get(v) for v in truncated.values()]).any(axis=0)
 
             # compute the cumulative sum of the rewards and timesteps
             if self._cumulative_rewards is None:

--- a/skrl/multi_agents/torch/base.py
+++ b/skrl/multi_agents/torch/base.py
@@ -403,10 +403,11 @@ class MultiAgent(ABC):
             self._cumulative_rewards.add_(_rewards)
             self._cumulative_timesteps.add_(1)
 
-            # check ended episodes
-            finished_episodes = (next(iter(terminated.values())) + next(iter(truncated.values()))).nonzero(
-                as_tuple=True
-            )[0]
+            # check ended episodes (any agent done counts as episode end)
+            finished_episodes = (
+                torch.stack(list(terminated.values())).any(dim=0)
+                | torch.stack(list(truncated.values())).any(dim=0)
+            ).nonzero(as_tuple=True)[0]
             if finished_episodes.numel():
 
                 # storage cumulative rewards and timesteps


### PR DESCRIPTION
Fixes #289.

## Problem

`MultiAgent.record_transition` uses `next(iter(terminated.values()))` and `next(iter(truncated.values()))` to determine which environments finished an episode. This only checks the **first agent** in the dictionary, so if any other agent terminates first, the cumulative rewards and timesteps are not reset and tracking is wrong.

## Fix

Replace the single-agent check with a logical OR across all agents:

**PyTorch backend** (`multi_agents/torch/base.py`):
```python
# Before (only first agent checked):
finished_episodes = (next(iter(terminated.values())) + next(iter(truncated.values()))).nonzero(...)

# After (all agents checked via OR):
finished_episodes = (
    torch.stack(list(terminated.values())).any(dim=0)
    | torch.stack(list(truncated.values())).any(dim=0)
).nonzero(as_tuple=True)[0]
```

**JAX backend** (`multi_agents/jax/base.py`):
```python
# Before:
_terminated = next(iter(terminated.values()))
_truncated = next(iter(truncated.values()))

# After:
_terminated = np.stack([jax.device_get(v) for v in terminated.values()]).any(axis=0)
_truncated = np.stack([jax.device_get(v) for v in truncated.values()]).any(axis=0)
```

An episode is considered finished when **any** agent signals termination or truncation — consistent with cooperative multi-agent environments where agents share a joint episode boundary.