### PR TITLE
Fix missing Weights & Biases metric logging for tracking data

### DIFF
--- a/skrl/agents/torch/base.py
+++ b/skrl/agents/torch/base.py
@@ -11,6 +11,11 @@ from abc import ABC, abstractmethod
 import gymnasium
 from packaging import version
 
+try:
+    import wandb
+except ImportError:  # pragma: no cover
+    wandb = None
+
 import numpy as np
 import torch
 
@@ -204,6 +209,12 @@ class Agent(ABC):
 
         # setup Weights & Biases
         if self.cfg.experiment.wandb:
+            if wandb is None:
+                raise RuntimeError(
+                    "Weights & Biases is enabled in the agent configuration "
+                    "but the `wandb` package is not installed. Install it with "
+                    "`pip install wandb` or set `cfg.experiment.wandb = False`."
+                )
             # save experiment configuration
             try:
                 models_cfg = {k: v.net._modules for (k, v) in self.models.items()}
@@ -216,9 +227,6 @@ class Agent(ABC):
             wandb_kwargs.setdefault("sync_tensorboard", True)
             wandb_kwargs.setdefault("config", {})
             wandb_kwargs["config"].update(wandb_config)
-            # init Weights & Biases
-            import wandb
-
             wandb.init(**wandb_kwargs)
 
         # main entry to log data for consumption and visualization by TensorBoard
@@ -252,6 +260,8 @@ class Agent(ABC):
         :param timesteps: Number of timesteps.
         """
         for k, v in self.tracking_data.items():
+            if self.cfg.experiment.wandb and wandb.run is not None:
+                wandb.log({k: float(np.mean(v))}, step=timestep)
             if k.endswith("(min)"):
                 self.writer.add_scalar(tag=k, value=np.min(v), timestep=timestep)
             elif k.endswith("(max)"):


### PR DESCRIPTION
📝 Description
This PR fixes an issue where certain training metrics (e.g., rewards) were not appearing in Weights & Biases, even when sync_tensorboard=True was enabled.

🔧 Problem
Although W&B was configured to sync TensorBoard logs, some metrics stored in self.tracking_data were not consistently propagated to W&B dashboards. This resulted in incomplete experiment tracking, particularly for key RL metrics such as episode rewards.

💡 Root cause
W&B TensorBoard synchronization does not reliably capture all scalar logs in this setup, especially when metrics are updated outside of immediate TensorBoard flush cycles.

✅ Solution
- Add explicit W&B logging for self.tracking_data via wandb.log
- Ensure logging only occurs when 1) W&B is enabled in config, and 2) wandb is installed. 

✨ Change summary
- Added safe import handling for wandb
- Added runtime check for wandb.run
- Added explicit metric logging alongside TensorBoard logging
```python
if self.cfg.experiment.wandb and wandb.run is not None:
    wandb.log({k: float(np.mean(v))}, step=timestep)
```

📊 Impact
- Restores missing metrics in W&B dashboards (including rewards)
- Keeps TensorBoard logging unchanged
- Maintains backward compatibility when W&B is disabled or not installed
- Improves experiment reproducibility and monitoring reliability