### PR TITLE
feat(agents/torch): optional checkpoint_metadata carried in grouped checkpoints

### DIFF
--- a/skrl/agents/torch/base.py
+++ b/skrl/agents/torch/base.py
@@ -135,6 +135,10 @@ class Agent(ABC):
         self.checkpoint_modules = {}
         self.checkpoint_interval = self.cfg.experiment.checkpoint_interval
         self.checkpoint_best_modules = {"timestep": 0, "reward": -(2**31), "saved": False, "modules": {}}
+        # optional, arbitrary metadata carried verbatim in grouped checkpoints. Set this attribute
+        # (e.g. ``agent.checkpoint_metadata = {...}``) before saving to record run information (git
+        # revision, environment id, notes) that travels with the policy; restored by ``load``.
+        self.checkpoint_metadata: dict[str, Any] = {}
 
         # experiment directory
         directory = (
@@ -286,6 +290,8 @@ class Agent(ABC):
         # whole agent
         else:
             modules = {name: self._get_internal_value(module) for name, module in self.checkpoint_modules.items()}
+            if self.checkpoint_metadata:
+                modules["__metadata__"] = self.checkpoint_metadata
             torch.save(modules, os.path.join(self.experiment_dir, "checkpoints", f"agent_{tag}.pt"))
 
         # best modules
@@ -300,6 +306,8 @@ class Agent(ABC):
             # whole agent
             else:
                 modules = {name: self.checkpoint_best_modules["modules"][name] for name in self.checkpoint_modules}
+                if self.checkpoint_metadata:
+                    modules["__metadata__"] = self.checkpoint_metadata
                 torch.save(modules, os.path.join(self.experiment_dir, "checkpoints", "best_agent.pt"))
             self.checkpoint_best_modules["saved"] = True
 
@@ -419,6 +427,8 @@ class Agent(ABC):
         :param path: Path to save the agent to.
         """
         modules = {name: self._get_internal_value(module) for name, module in self.checkpoint_modules.items()}
+        if self.checkpoint_metadata:
+            modules["__metadata__"] = self.checkpoint_metadata
         torch.save(modules, path)
 
     def load(self, path: str) -> None:
@@ -435,7 +445,12 @@ class Agent(ABC):
         else:
             modules = torch.load(path, map_location=self.device)
         if type(modules) is dict:
+            # restore optional opaque metadata carried alongside the modules (see save / ExperimentCfg)
+            if "__metadata__" in modules:
+                self.checkpoint_metadata = modules["__metadata__"]
             for name, data in modules.items():
+                if name == "__metadata__":
+                    continue
                 module = self.checkpoint_modules.get(name, None)
                 if module is not None:
                     if hasattr(module, "load_state_dict"):

--- a/tests/agents/torch/test_checkpoint_metadata.py
+++ b/tests/agents/torch/test_checkpoint_metadata.py
@@ -1,0 +1,97 @@
+"""The optional ``Agent.checkpoint_metadata`` attribute is carried through a grouped checkpoint.
+
+A user may set ``agent.checkpoint_metadata`` to arbitrary, opaque metadata (run information, an
+environment id, notes). When non-empty it is saved verbatim under the reserved ``"__metadata__"``
+key in a grouped checkpoint and restored by ``load``. skrl takes no position on its contents.
+"""
+import dataclasses
+import os
+import tempfile
+
+import gymnasium
+
+from skrl.agents.torch.ppo import PPO as Agent
+from skrl.agents.torch.ppo import PPO_CFG as AgentCfg
+from skrl.memories.torch import RandomMemory
+from skrl.utils.model_instantiators.torch import deterministic_model, gaussian_model
+
+from ...utilities import SingleAgentEnv
+
+
+def _make_agent():
+    observation_space = gymnasium.spaces.Box(low=-1, high=1, shape=(4,))
+    action_space = gymnasium.spaces.Box(low=-1, high=1, shape=(3,))
+    env = SingleAgentEnv(
+        observation_space=observation_space,
+        state_space=None,
+        action_space=action_space,
+        num_envs=1,
+        device="cpu",
+        ml_framework="torch",
+    )
+    net = [{"name": "net", "input": "OBSERVATIONS", "layers": [4], "activations": "relu"}]
+    models = {
+        "policy": gaussian_model(
+            observation_space=env.observation_space,
+            state_space=env.state_space,
+            action_space=env.action_space,
+            device=env.device,
+            network=net,
+            output="ACTIONS",
+        ),
+        "value": deterministic_model(
+            observation_space=env.observation_space,
+            state_space=env.state_space,
+            action_space=env.action_space,
+            device=env.device,
+            network=net,
+            output="ONE",
+        ),
+    }
+    memory = RandomMemory(memory_size=4, num_envs=env.num_envs, device=env.device)
+    cfg = dataclasses.asdict(AgentCfg())
+    cfg["experiment"]["write_interval"] = 0
+    cfg["experiment"]["checkpoint_interval"] = 0
+    return Agent(
+        models=models,
+        memory=memory,
+        cfg=cfg,
+        observation_space=env.observation_space,
+        state_space=env.state_space,
+        action_space=env.action_space,
+        device=env.device,
+    )
+
+
+def test_default_checkpoint_metadata_is_empty():
+    assert _make_agent().checkpoint_metadata == {}
+
+
+def test_metadata_saved_and_restored():
+    meta = {"git_revision": "abc123", "env": "CartPole-v1", "note": "smoke run"}
+    src = _make_agent()
+    src.checkpoint_metadata = meta
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "agent.pt")
+        src.save(path)
+
+        dst = _make_agent()
+        assert dst.checkpoint_metadata == {}
+        dst.load(path)
+        assert dst.checkpoint_metadata == meta
+
+
+def test_no_metadata_key_when_unset():
+    import torch
+
+    src = _make_agent()  # checkpoint_metadata left empty
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "agent.pt")
+        src.save(path)
+        saved = torch.load(path, weights_only=False)
+        assert "__metadata__" not in saved  # additive: no change to existing checkpoints
+
+        # loading a metadata-less checkpoint leaves the attribute untouched and emits no warning
+        dst = _make_agent()
+        dst.load(path)
+        assert dst.checkpoint_metadata == {}


### PR DESCRIPTION
### What

Exposes an optional `Agent.checkpoint_metadata` dict (default empty). When non-empty, it is saved verbatim under a reserved `"__metadata__"` key in a grouped checkpoint (in both `save` and the grouped branch of `write_checkpoint`) and restored by `load`. skrl takes no position on its contents: the value is carried and restored opaquely, so run information (git revision, environment id, free-form notes) can travel with the policy.

### Why

It is often useful for a saved policy to carry a bit of provenance about the run that produced it, without a sidecar file. This is a small, opt-in way to do that.

### Usage

```python
agent = PPO(models=..., memory=..., cfg=...)
agent.checkpoint_metadata = {"git_revision": "abc123", "env": "Isaac-Velocity-Flat-Anymal-D-v0"}
# ... train / save ...
# on a freshly constructed agent:
agent2.load(path)
agent2.checkpoint_metadata  # -> {"git_revision": "abc123", ...}
```

### Notes

- **Additive / back-compatible.** When the attribute is empty (the default), no `"__metadata__"` key is written, so existing checkpoints are byte-identical, and `load` skips the reserved key silently.
- **No config schema change.** The attribute is set directly, so the experiment-config key checks (and `ExperimentCfg`) are untouched.
- **Scope.** Stored in grouped checkpoints (`store_separately=False`); separate-file checkpoints are unchanged.
- This PR is scoped to the **torch** base agent. The identical change applies to the jax base agent; glad to mirror it here or in a follow-up with a jax test, whichever you prefer.

### Tests

`tests/agents/torch/test_checkpoint_metadata.py`: default is empty; metadata round-trips through `save`/`load`; no `"__metadata__"` key is written (and no warning on load) when unset.
