### PR TITLE
Fix finished-episode tracking across all agents

### DIFF
--- a/skrl/multi_agents/jax/base.py
+++ b/skrl/multi_agents/jax/base.py
@@ -402,8 +402,6 @@ class MultiAgent(ABC):
         """
         if self.write_interval > 0:
             _rewards = sum(rewards.values())
-            _terminated = next(iter(terminated.values()))
-            _truncated = next(iter(truncated.values()))
 
             # compute the cumulative sum of the rewards and timesteps
             if self._cumulative_rewards is None:
@@ -412,8 +410,8 @@ class MultiAgent(ABC):
 
             # TODO: find a better way to avoid https://jax.readthedocs.io/en/latest/errors.html#jax.errors.ConcretizationTypeError
             _rewards = jax.device_get(_rewards)
-            _terminated = jax.device_get(_terminated)
-            _truncated = jax.device_get(_truncated)
+            _terminated = np.stack(jax.device_get(list(terminated.values()))).any(axis=0)
+            _truncated = np.stack(jax.device_get(list(truncated.values()))).any(axis=0)
 
             self._cumulative_rewards += _rewards
             self._cumulative_timesteps += 1

--- a/skrl/multi_agents/torch/base.py
+++ b/skrl/multi_agents/torch/base.py
@@ -404,9 +404,9 @@ class MultiAgent(ABC):
             self._cumulative_timesteps.add_(1)
 
             # check ended episodes
-            finished_episodes = (next(iter(terminated.values())) + next(iter(truncated.values()))).nonzero(
-                as_tuple=True
-            )[0]
+            _terminated = torch.stack(tuple(terminated.values())).any(dim=0)
+            _truncated = torch.stack(tuple(truncated.values())).any(dim=0)
+            finished_episodes = (_terminated | _truncated).nonzero(as_tuple=True)[0]
             if finished_episodes.numel():
 
                 # storage cumulative rewards and timesteps

--- a/tests/multi_agents/jax/test_base.py
+++ b/tests/multi_agents/jax/test_base.py
@@ -1,0 +1,59 @@
+import jax.numpy as jnp
+import numpy as np
+
+from skrl.multi_agents.jax.base import ExperimentCfg, MultiAgent, MultiAgentCfg
+
+
+class _TestMultiAgent(MultiAgent):
+    def act(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def pre_interaction(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def post_interaction(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def update(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+def test_record_transition_checks_finished_state_for_all_agents():
+    """Check that a non-first agent can finish each vectorized environment."""
+    possible_agents = ["agent_0", "agent_1", "agent_2"]
+    agent = _TestMultiAgent(
+        cfg=MultiAgentCfg(experiment=ExperimentCfg(write_interval=1)),
+        possible_agents=possible_agents,
+        models={uid: {} for uid in possible_agents},
+    )
+
+    agent.record_transition(
+        observations={},
+        states={},
+        actions={},
+        rewards={
+            "agent_0": jnp.array([[1.0], [2.0], [3.0]]),
+            "agent_1": jnp.array([[10.0], [20.0], [30.0]]),
+            "agent_2": jnp.zeros((3, 1)),
+        },
+        next_observations={},
+        next_states={},
+        terminated={
+            "agent_0": jnp.zeros((3, 1), dtype=bool),
+            "agent_1": jnp.array([[False], [True], [False]]),
+            "agent_2": jnp.zeros((3, 1), dtype=bool),
+        },
+        truncated={
+            "agent_0": jnp.zeros((3, 1), dtype=bool),
+            "agent_1": jnp.zeros((3, 1), dtype=bool),
+            "agent_2": jnp.array([[False], [False], [True]]),
+        },
+        infos={},
+        timestep=0,
+        timesteps=1,
+    )
+
+    assert list(agent._track_rewards) == [[22.0], [33.0]]
+    assert list(agent._track_timesteps) == [[1], [1]]
+    np.testing.assert_array_equal(agent._cumulative_rewards, np.array([[11.0], [0.0], [0.0]]))
+    np.testing.assert_array_equal(agent._cumulative_timesteps, np.array([[1], [0], [0]], dtype=np.int32))

--- a/tests/multi_agents/torch/test_base.py
+++ b/tests/multi_agents/torch/test_base.py
@@ -1,0 +1,58 @@
+import torch
+
+from skrl.multi_agents.torch.base import ExperimentCfg, MultiAgent, MultiAgentCfg
+
+
+class _TestMultiAgent(MultiAgent):
+    def act(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def pre_interaction(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def post_interaction(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def update(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+def test_record_transition_checks_finished_state_for_all_agents():
+    """Check that a non-first agent can finish each vectorized environment."""
+    possible_agents = ["agent_0", "agent_1", "agent_2"]
+    agent = _TestMultiAgent(
+        cfg=MultiAgentCfg(experiment=ExperimentCfg(write_interval=1)),
+        possible_agents=possible_agents,
+        models={uid: {} for uid in possible_agents},
+    )
+
+    agent.record_transition(
+        observations={},
+        states={},
+        actions={},
+        rewards={
+            "agent_0": torch.tensor([[1.0], [2.0], [3.0]]),
+            "agent_1": torch.tensor([[10.0], [20.0], [30.0]]),
+            "agent_2": torch.zeros(3, 1),
+        },
+        next_observations={},
+        next_states={},
+        terminated={
+            "agent_0": torch.zeros(3, 1, dtype=torch.bool),
+            "agent_1": torch.tensor([[False], [True], [False]]),
+            "agent_2": torch.zeros(3, 1, dtype=torch.bool),
+        },
+        truncated={
+            "agent_0": torch.zeros(3, 1, dtype=torch.bool),
+            "agent_1": torch.zeros(3, 1, dtype=torch.bool),
+            "agent_2": torch.tensor([[False], [False], [True]]),
+        },
+        infos={},
+        timestep=0,
+        timesteps=1,
+    )
+
+    assert list(agent._track_rewards) == [[22.0], [33.0]]
+    assert list(agent._track_timesteps) == [[1], [1]]
+    torch.testing.assert_close(agent._cumulative_rewards, torch.tensor([[11.0], [0.0], [0.0]]))
+    torch.testing.assert_close(agent._cumulative_timesteps, torch.tensor([[1], [0], [0]], dtype=torch.int32))


### PR DESCRIPTION
Fixes #289.

## Problem and reasoning

Multi-agent episode statistics sum rewards from every agent, but the completion path only inspected the first value in each `terminated` and `truncated` dictionary. This made tracking depend on dictionary insertion order: if the first agent remained active while a later agent ended an environment, that episode was not recorded and its cumulative team reward and timestep count continued into the next episode.

The tracked state is one team-level reward and timestep value per vectorized environment. The corresponding completion signal therefore needs to be reduced to the same environment dimension. An environment is complete when any agent reports either termination or truncation. Reducing with `any` also guarantees one environment index when several agents finish together, so statistics are recorded and reset exactly once.

## Implementation

- Stack all per-agent termination flags and reduce them across the agent dimension.
- Apply the same reduction to truncation flags, then take their union per environment.
- Keep the existing host-side JAX tracking path by transferring the signal collection before the NumPy reduction.
- Use equivalent Torch and JAX behavior so the two multi-agent backends do not diverge.

## Regression coverage

The new backend-specific tests use three agents and three vectorized environments:

- the first agent reports no completed environments;
- the second agent terminates environment 1;
- the third agent truncates environment 2.

They verify that the completed team rewards are exactly `22` and `33`, both episode lengths are recorded as one step, only those two environments are reset, and environment 0 retains its cumulative reward and timestep.

With the production change reverted while keeping the tests, both regressions fail because no episode is recorded. With this change, both pass.

## Validation

- `pytest -q tests/multi_agents/torch/test_base.py tests/multi_agents/jax/test_base.py` — 2 passed
- `pytest -q tests/multi_agents/torch` — 16 passed, 15 skipped
- `pytest -q tests/multi_agents/jax` — 7 passed, 6 skipped
- `pre-commit run --all-files` — passed

The skipped tests are existing CUDA-conditional cases on a CPU-only test environment.
